### PR TITLE
Create CI job based on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
+      with:
+        submodules: true
     - name: Setup dependencies
       run: |
         sudo apt update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup dependencies
       run: |
         sudo apt update
-        sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended latex-xcolor xsltproc
+        sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc
       
     - name: Build the document
       run: make biblio forcetex html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Test building the standard
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -23,3 +23,8 @@ jobs:
       run: |
         test -f ConeSearch.pdf
         test -f ConeSearch.bbl
+        
+    - uses: actions/upload-artifact@v1
+      with:
+        name: pdf preview
+        path: ConeSearch.pdf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Test building the standard
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup dependencies
+      run: sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended latex-xcolor xsltproc
+      
+    - name: Build the document
+      run: make biblio forcetex html
+      
+    - name: Check the output
+      run: |
+        test -f ConeSearch.pdf
+        test -f ConeSearch.html
+        test -f ConeSearch.bbl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup dependencies
-      run: sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended latex-xcolor xsltproc
+      run: |
+        sudo apt update
+        sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended latex-xcolor xsltproc
       
     - name: Build the document
       run: make biblio forcetex html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,9 @@ jobs:
         sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc
       
     - name: Build the document
-      run: make biblio forcetex html
+      run: make biblio forcetex
       
     - name: Check the output
       run: |
         test -f ConeSearch.pdf
-        test -f ConeSearch.html
         test -f ConeSearch.bbl


### PR DESCRIPTION
Adds an automated build of the PDF on each push to the repository to check the latex code is sound. 

The built PDF can be downloaded on the checks page, where there is an 'artifacts' link in the right above the build log. This will download a zip containing the PDF.